### PR TITLE
feat: add a replay button under the info embed

### DIFF
--- a/src/handlers/button_cmd_handler.js
+++ b/src/handlers/button_cmd_handler.js
@@ -1,0 +1,37 @@
+const { generateYoutubeInfoEmbed } = require('../templates/embeds/youtube_infomation');
+const { generateMusicPlayerCtrlActionRow } = require('../templates/rows/music_player_control_buttons');
+
+function buttonCommandHandler(_, interaction, audioPlayer) {
+
+    if (!interaction.isButton()) return;
+
+    const { customId } = interaction;
+    
+    switch(customId) {
+        case 'queue-music':
+            const voiceChannel = interaction.member.voice.channel;
+            const url = interaction.message.embeds[0].url;
+
+            if(voiceChannel == null){
+                interaction.reply("請加入語音頻道以使用此功能!"); 
+                return;
+            }
+
+            audioPlayer.connectVoiceChannel(voiceChannel);
+            audioPlayer.playYoutube(url);
+            
+            interaction.deferReply();
+            audioPlayer.once('youtubeInfo', (info) => interaction.editReply({ 
+                embeds: [generateYoutubeInfoEmbed(info)],
+                components: [generateMusicPlayerCtrlActionRow()]
+            }));
+            break;
+        default:
+            interaction.reply("未知的指令");
+            break;
+    }
+}
+
+module.exports = {
+    buttonCommandHandler
+}

--- a/src/handlers/button_cmd_handler.test.js
+++ b/src/handlers/button_cmd_handler.test.js
@@ -1,0 +1,124 @@
+const { AudioPlayer } = require('../players/audio_player');
+const { buttonCommandHandler } = require('./button_cmd_handler');
+
+jest.mock('../players/audio_player');
+
+function generateMockClient() {
+  return {
+    user: 'Bot',
+    channels: {
+      cache: {
+        get: jest.fn()
+      }
+    },
+  }
+}
+
+function generateMockInteraction() {
+  return {
+    isButton: jest.fn(() => true),
+    message: {
+      embeds: [
+        {
+          url: 'url'
+        }
+      ]
+    },
+    member: {
+      voice: {
+        channel: null
+      }
+    },
+    channel: {
+      id: null
+    },
+    customId: null,
+    options: {
+      getSubcommand: jest.fn(() => null),
+      getString: jest.fn((type) => type),
+    },
+    reply: jest.fn(),
+    deferReply: jest.fn(),
+    editReply: jest.fn()
+  }
+}
+
+describe('Test buttonCommandHandler', () => {
+  let client;
+  let interaction;
+  let audioPlayer;
+
+  beforeEach(() => {
+    client = generateMockClient();
+    audioPlayer = new AudioPlayer();
+  });
+
+  describe('Given the interaction is not a button', () => {
+
+    beforeEach(() => {
+      interaction = generateMockInteraction();
+      interaction.isButton = jest.fn(() => false);
+    });
+
+    test('When receiving any interaction', () => {
+  
+      buttonCommandHandler(client, interaction, audioPlayer);
+  
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Given the interaction is a button', () => {
+
+    beforeEach(() => {
+      interaction = generateMockInteraction();
+      interaction.isButton = jest.fn(() => true);
+    });
+
+    test('When receiving a unknown interaction', () => {
+      interaction.customId = null;
+  
+      buttonCommandHandler(client, interaction, audioPlayer);
+  
+      expect(interaction.reply).toHaveBeenCalledWith('未知的指令');
+    });
+
+    describe('Given the user is not in any voice channel', () => {
+
+      beforeEach(() => {
+        interaction.member.voice.channel = null;
+      });
+
+      test('When receiving a queue muisc interaction', () => {
+        interaction.customId = 'queue-music';
+
+        buttonCommandHandler(client, interaction, audioPlayer);
+    
+        expect(interaction.reply).toHaveBeenCalledWith('請加入語音頻道以使用此功能!');
+      });
+    });
+
+    describe('Given the user is in a voice channel', () => {
+
+      beforeEach(() => {
+        interaction.member.voice.channel = '測試語音頻道';
+      });
+
+      describe('Given the user send a queue muisc interaction', () => {
+
+        beforeEach(() => {
+          process.env.SONG_REQUEST_CHANNEL_ID = '點歌頻道';
+          interaction.channel.id = '點歌頻道';
+        });
+
+        test('When receiving a queue muisc interaction', () => {
+          interaction.customId = 'queue-music';
+      
+          buttonCommandHandler(client, interaction, audioPlayer);
+      
+          expect(audioPlayer.playYoutube).toHaveBeenCalledWith('url');
+        });
+      });
+    });
+  });
+});

--- a/src/handlers/slash_cmd_handler.js
+++ b/src/handlers/slash_cmd_handler.js
@@ -2,6 +2,7 @@ const { generateYoutubeInfoEmbed } = require('../templates/embeds/youtube_infoma
 const { generateSkipMusicEmbed } = require('../templates/embeds/skip_music');
 const { generateResetAudioPlayerEmbed } = require('../templates/embeds/reset_audio_player');
 const { generateToggleAudioPlayerLoopingEmbed } = require('../templates/embeds/toggle_audio_player_looping');
+const { generateMusicPlayerCtrlActionRow } = require('../templates/rows/music_player_control_buttons');
 
 function slashCommandHandler(client, interaction, audioPlayer) {
 
@@ -30,7 +31,11 @@ function slashCommandHandler(client, interaction, audioPlayer) {
             switch(interaction.options.getSubcommand()){
                 case 'playsong':
                     audioPlayer.playYoutube(interaction.options.getString('url'));
-                    audioPlayer.once('youtubeInfo', (info) => interaction.reply({ embeds: [generateYoutubeInfoEmbed(info)] }));
+                    interaction.deferReply();
+                    audioPlayer.once('youtubeInfo', (info) => interaction.editReply({ 
+                        embeds: [generateYoutubeInfoEmbed(info)],
+                        components: [generateMusicPlayerCtrlActionRow()]
+                    }));
                     break;
                 case 'playlocal':
                     audioPlayer.playLocal(interaction.options.getString('file'));

--- a/src/handlers/slash_cmd_handler.test.js
+++ b/src/handlers/slash_cmd_handler.test.js
@@ -40,6 +40,8 @@ function generateMockInteraction() {
       getString: jest.fn((type) => type),
     },
     reply: jest.fn(),
+    deferReply: jest.fn(),
+    editReply: jest.fn()
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ const { Client, Intents } = require('discord.js');
 const { registerSlashCommands } = require('./utils/slash_cmd_registrator');
 const { messageHandler } = require('./handlers/message_handler');
 const { slashCommandHandler } = require('./handlers/slash_cmd_handler');
+const { buttonCommandHandler } = require('./handlers/button_cmd_handler');
 
 const audioPlayer = new AudioPlayer();
 
@@ -43,6 +44,10 @@ client.on('messageCreate', message => {
 
 client.on('interactionCreate', interaction => {
     slashCommandHandler(client, interaction, audioPlayer);
+});
+
+client.on('interactionCreate', interaction => {
+    buttonCommandHandler(client, interaction, audioPlayer);
 });
 
 client.login(process.env.DISCORD_TOKEN);

--- a/src/templates/rows/music_player_control_buttons.js
+++ b/src/templates/rows/music_player_control_buttons.js
@@ -1,0 +1,16 @@
+const { MessageButton, MessageActionRow } = require('discord.js');
+
+function generateMusicPlayerCtrlActionRow() {
+
+  const queueMusicBtn = new MessageButton()
+      .setCustomId('queue-music')
+      .setLabel('▶️加入佇列')
+      .setStyle('SECONDARY');
+
+  return new MessageActionRow()
+      .addComponents(queueMusicBtn);
+}
+
+module.exports = {
+  generateMusicPlayerCtrlActionRow
+}


### PR DESCRIPTION
This commit has the following changes listed below:
- change the reply method from reply to deferReply to avoid the interaction timeout.
- Add a replay button under the info embed sent by the play youtube music function.
- Update the unit test to fit the new implementation.
- Add a new unit test for the button command handler.