### PR TITLE
fix: improve the Youtube player info mechanism

### DIFF
--- a/src/handlers/button_cmd_handler.js
+++ b/src/handlers/button_cmd_handler.js
@@ -17,14 +17,20 @@ async function buttonCommandHandler(_, interaction, audioPlayer) {
                 return;
             }
 
-            audioPlayer.connectVoiceChannel(voiceChannel);
-            audioPlayer.playYoutube(url);
-            
             await interaction.deferReply();
-            audioPlayer.once('youtubeInfo', (info) => interaction.editReply({ 
-                embeds: [generateYoutubeInfoEmbed(info)],
-                components: [generateMusicPlayerCtrlActionRow()]
-            }));
+
+            audioPlayer.connectVoiceChannel(voiceChannel);
+
+            try{
+                const info = await audioPlayer.playYoutube(url);
+                await interaction.editReply({
+                    embeds: [generateYoutubeInfoEmbed(info)],
+                    components: [generateMusicPlayerCtrlActionRow()]
+                });
+            } catch(e) {
+                await interaction.editReply("播放Youtube歌曲時發生例外狀況，詳情請見Console🥲");
+            }
+
             break;
         default:
             await interaction.reply("未知的指令");

--- a/src/handlers/button_cmd_handler.test.js
+++ b/src/handlers/button_cmd_handler.test.js
@@ -2,6 +2,24 @@ const { AudioPlayer } = require('../players/audio_player');
 const { buttonCommandHandler } = require('./button_cmd_handler');
 
 jest.mock('../players/audio_player');
+const playYoutubeMock = jest
+  .spyOn(AudioPlayer.prototype, 'playYoutube')
+  .mockImplementation(async () => {
+    return {
+      videoDetails: {
+        title: 'foo',
+        video_url: 'foo',
+        thumbnails: [
+          {
+            url: 'foo'
+          }
+        ],
+        ownerChannelName: 'foo',
+        lengthSeconds: 0,
+        publishDate: 'foo'
+      }
+    };
+  });
 
 function generateMockClient() {
   return {
@@ -116,7 +134,7 @@ describe('Test buttonCommandHandler', () => {
       
           await buttonCommandHandler(client, interaction, audioPlayer);
       
-          expect(audioPlayer.playYoutube).toHaveBeenCalledWith('url');
+          expect(playYoutubeMock).toHaveBeenCalledWith('url');
         });
       });
     });

--- a/src/handlers/slash_cmd_handler.js
+++ b/src/handlers/slash_cmd_handler.js
@@ -30,25 +30,36 @@ async function slashCommandHandler(client, interaction, audioPlayer) {
 
             switch(interaction.options.getSubcommand()){
                 case 'playsong':
-                    audioPlayer.playYoutube(interaction.options.getString('url'));
                     await interaction.deferReply();
-                    audioPlayer.once('youtubeInfo', (info) => interaction.editReply({ 
-                        embeds: [generateYoutubeInfoEmbed(info)],
-                        components: [generateMusicPlayerCtrlActionRow()]
-                    }));
+                    try {
+                        const info = await audioPlayer.playYoutube(interaction.options.getString('url'));
+                        await interaction.editReply({
+                            embeds: [generateYoutubeInfoEmbed(info)],
+                            components: [generateMusicPlayerCtrlActionRow()]
+                        });
+                    } catch(e) {
+                        await interaction.editReply("播放Youtube歌曲時發生例外狀況，詳情請見Console🥲");
+                    }
                     break;
                 case 'playlocal':
+                    await interaction.deferReply();
                     audioPlayer.playLocal(interaction.options.getString('file'));
-                    await interaction.reply(`即將播放 ${interaction.options.getString('file')}`);
+                    await interaction.editReply(`即將播放 ${interaction.options.getString('file')}`);
                     break;
                 case 'skip':
-                    audioPlayer.skip();
-                    await interaction.reply({ embeds: [generateSkipMusicEmbed()] });
+                    await interaction.deferReply();
+                    try {
+                        audioPlayer.skip();
+                        await interaction.editReply({ embeds: [generateSkipMusicEmbed()] });
+                    } catch(e) {
+                        await interaction.editReply("重播歌曲時發生例外狀況，詳情請見Console🥲");
+                    }
                     break;
                 case 'reset':
                 case 'fuckout':
+                    await interaction.deferReply();
                     audioPlayer.disconnectVoiceChannel();
-                    await interaction.reply({ embeds: [generateResetAudioPlayerEmbed()] });
+                    await interaction.editReply({ embeds: [generateResetAudioPlayerEmbed()] });
                     break;
                 case 'loop':
                     let looping = audioPlayer.toggleLooping();

--- a/src/handlers/slash_cmd_handler.test.js
+++ b/src/handlers/slash_cmd_handler.test.js
@@ -2,6 +2,24 @@ const { AudioPlayer } = require('../players/audio_player');
 const { slashCommandHandler } = require('./slash_cmd_handler');
 
 jest.mock('../players/audio_player');
+const playYoutubeMock = jest
+  .spyOn(AudioPlayer.prototype, 'playYoutube')
+  .mockImplementation(async () => {
+    return {
+      videoDetails: {
+        title: 'foo',
+        video_url: 'foo',
+        thumbnails: [
+          {
+            url: 'foo'
+          }
+        ],
+        ownerChannelName: 'foo',
+        lengthSeconds: 0,
+        publishDate: 'foo'
+      }
+    };
+  });
 jest.mock('../templates/embeds/skip_music', () => ({
   generateSkipMusicEmbed: jest.fn(() => 'SkipMusicEmbed')
 }));
@@ -150,7 +168,7 @@ describe('Test slashCommandHandler', () => {
       
           await slashCommandHandler(client, interaction, audioPlayer);
       
-          expect(audioPlayer.playYoutube).toHaveBeenCalledWith('url');
+          expect(playYoutubeMock).toHaveBeenCalledWith('url');
         });
 
         test('When receiving a musicbot interaction with a playlocal subcommand', async () => {
@@ -160,7 +178,7 @@ describe('Test slashCommandHandler', () => {
           await slashCommandHandler(client, interaction, audioPlayer);
       
           expect(audioPlayer.playLocal).toHaveBeenCalledWith('file');
-          expect(interaction.reply).toHaveBeenCalledWith('即將播放 file');
+          expect(interaction.editReply).toHaveBeenCalledWith('即將播放 file');
         });
 
         test('When receiving a musicbot interaction with a skip subcommand', async () => {
@@ -170,7 +188,7 @@ describe('Test slashCommandHandler', () => {
           await slashCommandHandler(client, interaction, audioPlayer);
       
           expect(audioPlayer.skip).toHaveBeenCalled();
-          expect(interaction.reply).toHaveBeenCalledWith(generateMockEmbed('SkipMusicEmbed'));
+          expect(interaction.editReply).toHaveBeenCalledWith(generateMockEmbed('SkipMusicEmbed'));
         });
 
         test('When receiving a musicbot interaction with a reset subcommand', async () => {
@@ -180,7 +198,7 @@ describe('Test slashCommandHandler', () => {
           await slashCommandHandler(client, interaction, audioPlayer);
       
           expect(audioPlayer.disconnectVoiceChannel).toHaveBeenCalled();
-          expect(interaction.reply).toHaveBeenCalledWith(generateMockEmbed('ResetAudioPlayerEmbed'));
+          expect(interaction.editReply).toHaveBeenCalledWith(generateMockEmbed('ResetAudioPlayerEmbed'));
         });
 
         test('When receiving a musicbot interaction with a fuckout subcommand', async () => {
@@ -190,7 +208,7 @@ describe('Test slashCommandHandler', () => {
           await slashCommandHandler(client, interaction, audioPlayer);
       
           expect(audioPlayer.disconnectVoiceChannel).toHaveBeenCalled();
-          expect(interaction.reply).toHaveBeenCalledWith(generateMockEmbed('ResetAudioPlayerEmbed'));
+          expect(interaction.editReply).toHaveBeenCalledWith(generateMockEmbed('ResetAudioPlayerEmbed'));
         });
 
         test('When receiving a musicbot interaction with a loop subcommand', async () => {

--- a/src/players/audio_player.test.js
+++ b/src/players/audio_player.test.js
@@ -16,11 +16,10 @@ jest.mock('fs', () => {
 });
 jest.mock('events');
 jest.mock('ytdl-core', () => {
-  return jest.fn(() => {
-    return {
-      on: jest.fn()
-    }
-  })
+  return {
+    getInfo: jest.fn(),
+    downloadFromInfo: jest.fn().mockReturnValue('mockYoutubeStream')
+  }
 });
 jest.mock('./music_queue');
 jest.mock('@discordjs/voice', () => {
@@ -85,9 +84,7 @@ function generateMockAudioResourceOptions(type, fileName) {
 }
 
 function generateMockYoutubeStream() {
-  return {
-    on: expect.any(Function)
-  };
+  return 'mockYoutubeStream';
 }
 
 function generateMockAudioResource(type, fileName) {
@@ -212,14 +209,14 @@ describe('Test AudioPlayer', () => {
     expect(connectionSubscribeFunc).toHaveBeenCalledTimes(1);
   });
 
-  it('Should be able to play the audio file on youtube', () => {
+  it('Should be able to play the audio file on youtube', async () => {
     const voiceChannel = generateMockVoiceChannel();
     const mockYoutubeStream = generateMockYoutubeStream();
     const mockAudioResource = generateMockAudioResource('youtube', 'https://www.youtube.com');
     const mockAudioResourceOption = generateMockAudioResourceOptions('youtube', 'https://www.youtube.com');
 
     audioPlayer.connectVoiceChannel(voiceChannel);
-    audioPlayer.playYoutube('https://www.youtube.com');
+    await audioPlayer.playYoutube('https://www.youtube.com');
 
     expect(createAudioResource).toHaveBeenCalledWith(mockYoutubeStream, mockAudioResourceOption);
     const mockMusicQueueInstance = MusicQueue.mock.instances[0];


### PR DESCRIPTION
This commit has the following changes listed below:
- Avoid replying to the channel with the same song information multiple times when the bot receives different song requests at the same time. This problem is caused by the incorrect use of event emitters. Now has been fixed by implementing an async workflow.
- Avoid interaction timeout issues by adjusting the flow of interaction responses.
- Update the unit test to fit the new implementation.